### PR TITLE
docs: add Sebastian Software README branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # eslint-plugin-lingui-typescript
 
+[![Powered by Sebastian Software](https://img.shields.io/badge/Powered%20by-Sebastian%20Software-00718d?style=flat-square)](https://oss.sebastian-software.com)
 [![npm version](https://img.shields.io/npm/v/eslint-plugin-lingui-typescript.svg)](https://www.npmjs.com/package/eslint-plugin-lingui-typescript)
 [![npm downloads](https://img.shields.io/npm/dm/eslint-plugin-lingui-typescript.svg)](https://www.npmjs.com/package/eslint-plugin-lingui-typescript)
 [![CI](https://github.com/sebastian-software/eslint-plugin-lingui-typescript/actions/workflows/ci.yml/badge.svg)](https://github.com/sebastian-software/eslint-plugin-lingui-typescript/actions/workflows/ci.yml)
@@ -269,3 +270,18 @@ Contributions welcome. See the [Contributing Guide](CONTRIBUTING.md) and [Code o
 ---
 
 Built by [Sebastian Software](https://www.sebastian-software.de)
+
+---
+
+<!-- sebastian-software-branding:start -->
+<p align="center">
+  <a href="https://oss.sebastian-software.com">
+    <img src="https://sebastian-brand.vercel.app/sebastian-software/logo-software.svg" alt="Sebastian Software" width="240" />
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://oss.sebastian-software.com">Open Source at Sebastian Software</a><br />
+  Copyright &copy; 2025&ndash;2026 Sebastian Software GmbH
+</p>
+<!-- sebastian-software-branding:end -->


### PR DESCRIPTION
Adds a consistent Sebastian Software brand badge near the existing README badge/header area and a shared footer linking to https://oss.sebastian-software.com.\n\nThis keeps the open-source project READMEs visually aligned across the organization while preserving each README's existing structure.\n\nFollow-ups applied from review:\n- Badge placement now follows each project's existing badge/header layout.\n- Footer separator has a blank line before it.\n- Links target the .com OSS site for the English version.\n- Footer copyright years are mapped from the relevant project history: 2025&ndash;2026.\n- Footer logo uses the hosted Sebastian Brand asset.